### PR TITLE
Add no-f-ads flag and commit tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ noob-commit --yes-to-modules
 # Include build artifacts (not recommended)
 noob-commit --yes-to-crap
 
+# Output the AI advice in Brazilian Portuguese
+noob-commit -b
+
 # Just commit, don't push
 noob-commit --no-push
 
@@ -134,6 +137,9 @@ nc
 ```bash
 # Include EVERYTHING (use with caution!)
 nc --ok-to-send-env --yes-to-modules --yes-to-crap
+
+# Get advice in Portuguese (for BR devs)
+nc -b
 ```
 
 ### Features 🔥
@@ -155,16 +161,18 @@ All the knobs you might want to turn:
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--model` | AI model to use | `gpt-4.1-mini` |
-| `--max-tokens` | How much the AI can ramble | `2000` |
-| `--dry-run` | Just show what would happen | `false` |
-| `--force` | Skip confirmations | `false` |
-| `--review` | Edit AI's message | `false` |
-| `--ok-to-send-env` | Include .env files | `false` |
-| `--yes-to-modules` | Include dependency folders | `false` |
-| `--yes-to-crap` | Include build artifacts | `false` |
-| `--no-push` | Don't push to remote | `false` |
-| `--setup-alias` | Setup 'nc' alias | - |
+| `-m, --model` | AI model to use | `gpt-4.1-mini` |
+| `-t, --max-tokens` | How much the AI can ramble | `2000` |
+| `-d, --dry-run` | Just show what would happen | `false` |
+| `-f, --force` | Skip confirmations | `false` |
+| `-r, --review` | Edit AI's message | `false` |
+| `-e, --ok-to-send-env` | Include .env files | `false` |
+| `-M, --yes-to-modules` | Include dependency folders | `false` |
+| `-c, --yes-to-crap` | Include build artifacts | `false` |
+| `-b, --br-huehuehue` | Output advice in Brazilian Portuguese | `false` |
+| `-a, --no-f-ads` | Disable the silly post-commit tagline | `false` |
+| `-p, --no-push` | Don't push to remote | `false` |
+| `-s, --setup-alias` | Setup 'nc' alias | - |
 
 ### What Gets Filtered? 🚫
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, JsonSchema, Serialize)]
 pub struct Commit {
@@ -9,15 +9,35 @@ pub struct Commit {
     pub description: String,
 }
 
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
+pub struct CommitAdvice {
+    /// Friendly message to the noob developer.
+    pub message: String,
+    /// The actual commit information.
+    pub commit: Commit,
+}
+
 impl ToString for Commit {
     fn to_string(&self) -> String {
         format!("{}\n\n{}", self.title, self.description)
     }
 }
 
+impl ToString for CommitAdvice {
+    fn to_string(&self) -> String {
+        format!("{}\n\n{}", self.message, self.commit.to_string())
+    }
+}
+
 impl Commit {
     pub fn new(title: String, description: String) -> Self {
         Self { title, description }
+    }
+}
+
+impl CommitAdvice {
+    pub fn new(message: String, commit: Commit) -> Self {
+        Self { message, commit }
     }
 }
 
@@ -31,29 +51,23 @@ mod tests {
             "Add noob-friendly features".to_string(),
             "Added self-deprecating humor and alias setup functionality for developers who are great at coding but terrible at git.".to_string(),
         );
-        
+
         assert_eq!(commit.title, "Add noob-friendly features");
         assert!(commit.description.contains("self-deprecating"));
     }
 
     #[test]
     fn test_commit_to_string() {
-        let commit = Commit::new(
-            "Fix stuff".to_string(),
-            "idk it works now".to_string(),
-        );
-        
+        let commit = Commit::new("Fix stuff".to_string(), "idk it works now".to_string());
+
         let result = commit.to_string();
         assert_eq!(result, "Fix stuff\n\nidk it works now");
     }
 
     #[test]
     fn test_commit_with_empty_description() {
-        let commit = Commit::new(
-            "Update README".to_string(),
-            "".to_string(),
-        );
-        
+        let commit = Commit::new("Update README".to_string(), "".to_string());
+
         let result = commit.to_string();
         assert_eq!(result, "Update README\n\n");
     }
@@ -64,18 +78,15 @@ mod tests {
             "Refactor code".to_string(),
             "Line 1\nLine 2\nLine 3".to_string(),
         );
-        
+
         let result = commit.to_string();
         assert_eq!(result, "Refactor code\n\nLine 1\nLine 2\nLine 3");
     }
 
     #[test]
     fn test_commit_serialization() {
-        let commit = Commit::new(
-            "Test commit".to_string(),
-            "This is a test".to_string(),
-        );
-        
+        let commit = Commit::new("Test commit".to_string(), "This is a test".to_string());
+
         let json = serde_json::to_string(&commit).unwrap();
         assert!(json.contains("Test commit"));
         assert!(json.contains("This is a test"));
@@ -85,8 +96,18 @@ mod tests {
     fn test_commit_deserialization() {
         let json = r#"{"title":"Test commit","description":"This is a test"}"#;
         let commit: Commit = serde_json::from_str(json).unwrap();
-        
+
         assert_eq!(commit.title, "Test commit");
         assert_eq!(commit.description, "This is a test");
+    }
+
+    #[test]
+    fn test_commit_advice_to_string() {
+        let commit = Commit::new("Init".to_string(), "First commit".to_string());
+        let advice = CommitAdvice::new("Be careful".to_string(), commit);
+        let result = advice.to_string();
+        assert!(result.contains("Be careful"));
+        assert!(result.contains("Init"));
+        assert!(result.contains("First commit"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,19 +3,19 @@ use async_openai::{
     types::{
         ChatCompletionRequestMessage, ChatCompletionRequestSystemMessage,
         ChatCompletionRequestSystemMessageContent, ChatCompletionRequestUserMessage,
-        ChatCompletionRequestUserMessageContent, CreateChatCompletionRequestArgs, 
-        ChatCompletionTool, ChatCompletionToolType, FunctionObject,
+        ChatCompletionRequestUserMessageContent, ChatCompletionTool, ChatCompletionToolType,
+        CreateChatCompletionRequestArgs, FunctionObject,
     },
 };
 use clap::Parser;
 use clap_verbosity_flag::{InfoLevel, Verbosity};
 use log::{error, info};
+use noob_commit::CommitAdvice;
 use question::{Answer, Question};
 use rand::prelude::*;
-use schemars::SchemaGenerator;
 use schemars::generate::SchemaSettings;
+use schemars::SchemaGenerator;
 use spinners::{Spinner, Spinners};
-use noob_commit::Commit;
 use std::{
     env,
     fs::{self, OpenOptions},
@@ -35,6 +35,7 @@ struct Cli {
     verbose: Verbosity<InfoLevel>,
 
     #[arg(
+        short = 'd',
         long = "dry-run",
         help = "🔍 Just show me what commit message you'd create (for anxious devs)"
     )]
@@ -47,22 +48,29 @@ struct Cli {
     )]
     review: bool,
 
-    #[arg(short, long, help = "⚡ YOLO mode - just commit everything (living dangerously)")]
+    #[arg(
+        short,
+        long,
+        help = "⚡ YOLO mode - just commit everything (living dangerously)"
+    )]
     force: bool,
 
     #[arg(
+        short = 'e',
         long = "ok-to-send-env",
         help = "🔓 Include .env files (for when you want to leak your API keys like a pro)"
     )]
     ok_to_send_env: bool,
 
     #[arg(
+        short = 'p',
         long = "no-push",
         help = "📦 Commit but don't push (for commitment-phobic developers)"
     )]
     no_push: bool,
 
     #[arg(
+        short = 't',
         long = "max-tokens",
         help = "🤖 How much the AI can ramble (higher = more verbose commits)",
         default_value = "2000"
@@ -70,6 +78,7 @@ struct Cli {
     max_tokens: u16,
 
     #[arg(
+        short = 'm',
         long = "model",
         help = "🧠 Pick your AI overlord (gpt-4.1-mini is cheap and good enough)",
         default_value = "gpt-4.1-mini"
@@ -77,54 +86,72 @@ struct Cli {
     model: String,
 
     #[arg(
+        short = 's',
         long = "setup-alias",
         help = "🛠️ Setup 'nc' alias for easy access"
     )]
     setup_alias: bool,
 
     #[arg(
+        short = 'M',
         long = "yes-to-modules",
         help = "📦 Include dependency folders (node_modules, venv, etc) - WARNING: This will make your repo HUGE!"
     )]
     yes_to_modules: bool,
 
     #[arg(
+        short = 'c',
         long = "yes-to-crap",
         help = "🗑️ Include cache/build artifacts (__pycache__, .DS_Store, etc) - Not recommended!"
     )]
     yes_to_crap: bool,
+
+    #[arg(
+        short = 'b',
+        long = "br-huehuehue",
+        help = "🇧🇷 Output advice in Brazilian Portuguese with extra humor"
+    )]
+    br_huehuehue: bool,
+
+    #[arg(
+        short = 'a',
+        long = "no-f-ads",
+        help = "🙊 Disable the silly post-commit tagline",
+        default_value_t = false
+    )]
+    no_f_ads: bool,
 }
 
 fn setup_alias() -> Result<(), Box<dyn std::error::Error>> {
     println!("🤡 Setting up 'nc' alias for noob-commit...");
-    
+
     let shell = env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
     let shell_name = Path::new(&shell).file_name().unwrap().to_str().unwrap();
-    
+
     let config_file = match shell_name {
         "zsh" => {
             let mut path = env::var("HOME")?;
             path.push_str("/.zshrc");
             path
-        },
+        }
         "bash" => {
             let mut path = env::var("HOME")?;
             path.push_str("/.bashrc");
             path
-        },
+        }
         "fish" => {
             let mut path = env::var("HOME")?;
             path.push_str("/.config/fish/config.fish");
             path
-        },
+        }
         _ => {
             println!("⚠️  Unknown shell: {}. Please manually add 'alias nc=noob-commit' to your shell config.", shell_name);
             return Ok(());
         }
     };
-    
+
     let alias_line = "alias nc='noob-commit'";
-    
+
     // Check if alias already exists
     if let Ok(content) = fs::read_to_string(&config_file) {
         if content.contains("alias nc") || content.contains("nc='noob-commit'") {
@@ -132,19 +159,22 @@ fn setup_alias() -> Result<(), Box<dyn std::error::Error>> {
             return Ok(());
         }
     }
-    
+
     // Add alias to config file
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
         .open(&config_file)?;
-    
+
     writeln!(file, "\n# Added by noob-commit")?;
     writeln!(file, "{}", alias_line)?;
-    
+
     println!("✅ Added 'nc' alias to {}", config_file);
-    println!("💡 Restart your terminal or run 'source {}' to use 'nc' command", config_file);
-    
+    println!(
+        "💡 Restart your terminal or run 'source {}' to use 'nc' command",
+        config_file
+    );
+
     Ok(())
 }
 
@@ -155,7 +185,7 @@ fn load_api_key() -> Result<String, String> {
             return Ok(key);
         }
     }
-    
+
     // If not in environment, try to load from .env file
     if let Ok(env_content) = fs::read_to_string(".env") {
         for line in env_content.lines() {
@@ -168,28 +198,29 @@ fn load_api_key() -> Result<String, String> {
             }
         }
     }
-    
+
     Err("🔑 Oops! You forgot to set OPENAI_API_KEY. Even noobs need API keys!\n💡 Get one at https://platform.openai.com/api-keys".to_string())
 }
 
 fn is_security_file(filename: &str) -> bool {
     // Only block exact security file names
-    matches!(filename, 
-        ".env" |
-        ".env.local" |
-        ".env.production" |
-        ".env.development" |
-        ".env.test" |
-        ".env.staging" |
-        ".npmrc" |
-        ".pypirc" |
-        "credentials" |
-        "secrets.yml" |
-        "secrets.yaml" |
-        "id_rsa" |
-        "id_ed25519" |
-        "id_ecdsa" |
-        "id_dsa"
+    matches!(
+        filename,
+        ".env"
+            | ".env.local"
+            | ".env.production"
+            | ".env.development"
+            | ".env.test"
+            | ".env.staging"
+            | ".npmrc"
+            | ".pypirc"
+            | "credentials"
+            | "secrets.yml"
+            | "secrets.yaml"
+            | "id_rsa"
+            | "id_ed25519"
+            | "id_ecdsa"
+            | "id_dsa"
     ) || filename.starts_with(".env.") && filename.ends_with(".local")
 }
 
@@ -197,7 +228,8 @@ fn is_module_directory(path: &str) -> bool {
     // Check if any part of the path contains common module/dependency directories
     let parts: Vec<&str> = path.split('/').collect();
     for part in parts {
-        if matches!(part,
+        if matches!(
+            part,
             "node_modules" |
             "venv" |
             ".venv" |
@@ -221,7 +253,7 @@ fn is_module_directory(path: &str) -> bool {
             "Pods" |    // iOS
             ".gradle" | // Android
             "build" |   // Various build systems
-            "dist"      // Distribution folders
+            "dist" // Distribution folders
         ) {
             return true;
         }
@@ -231,33 +263,38 @@ fn is_module_directory(path: &str) -> bool {
 
 fn is_crap_file(path: &str) -> bool {
     // Check if the path contains cache/build artifacts
-    let filename = Path::new(path).file_name()
+    let filename = Path::new(path)
+        .file_name()
         .and_then(|f| f.to_str())
         .unwrap_or("");
-    
+
     // Check exact filenames
-    if matches!(filename,
-        ".DS_Store" |
-        "Thumbs.db" |
-        "desktop.ini" |
-        ".gitkeep" |
-        ".keep"
+    if matches!(
+        filename,
+        ".DS_Store" | "Thumbs.db" | "desktop.ini" | ".gitkeep" | ".keep"
     ) {
         return true;
     }
-    
+
     // Check if it's an editor temp file
     if filename.ends_with(".swp") || filename.ends_with(".swo") || filename.ends_with(".swn") {
         return true;
     }
-    
+
     // Check if it's a backup/temp file
-    if filename.ends_with(".log") || filename.ends_with(".tmp") || filename.ends_with(".temp") ||
-       filename.ends_with(".cache") || filename.ends_with(".bak") || filename.ends_with(".backup") ||
-       filename.ends_with(".old") || filename.ends_with(".orig") || filename.ends_with("~") {
+    if filename.ends_with(".log")
+        || filename.ends_with(".tmp")
+        || filename.ends_with(".temp")
+        || filename.ends_with(".cache")
+        || filename.ends_with(".bak")
+        || filename.ends_with(".backup")
+        || filename.ends_with(".old")
+        || filename.ends_with(".orig")
+        || filename.ends_with("~")
+    {
         return true;
     }
-    
+
     // Check file extensions more carefully
     // We want to filter actual compiled/generated files, not files that happen to contain
     // these strings in their name (e.g., "demo.pyc" as a regular file name)
@@ -273,8 +310,11 @@ fn is_crap_file(path: &str) -> bool {
                     return true;
                 }
                 // Also filter if it's in a directory that suggests it's compiled
-                if path.contains("/build/") || path.contains("/dist/") || 
-                   path.contains("/.eggs/") || path.contains("/wheelhouse/") {
+                if path.contains("/build/")
+                    || path.contains("/dist/")
+                    || path.contains("/.eggs/")
+                    || path.contains("/wheelhouse/")
+                {
                     return true;
                 }
                 // For standalone .pyc files, we'll be conservative and filter them
@@ -283,32 +323,39 @@ fn is_crap_file(path: &str) -> bool {
                     return true;
                 }
                 return false;
-            },
+            }
             // Native libraries - be careful not to filter legitimate shared libraries
             "so" | "dylib" | "dll" => {
                 // Filter if it looks like a build artifact
-                return path.contains("/build/") || path.contains("/dist/") || 
-                       path.contains("/target/") || path.contains("/.libs/");
-            },
+                return path.contains("/build/")
+                    || path.contains("/dist/")
+                    || path.contains("/target/")
+                    || path.contains("/.libs/");
+            }
             // Java
-            "class" => return true,  // Java compiled files
+            "class" => return true, // Java compiled files
             "jar" => {
                 // JAR files in dependencies folders should be filtered
-                return path.contains("/lib/") || path.contains("/libs/") || 
-                       path.contains("/vendor/") || path.contains("/dependencies/");
-            },
+                return path.contains("/lib/")
+                    || path.contains("/libs/")
+                    || path.contains("/vendor/")
+                    || path.contains("/dependencies/");
+            }
             // C/C++ objects
             "o" | "a" => {
                 // Object files and archives are typically build artifacts
                 return true;
-            },
+            }
             // Windows executables
             "exe" => {
                 // Filter if in common build directories
-                return path.contains("/build/") || path.contains("/dist/") || 
-                       path.contains("/target/") || path.contains("/bin/") ||
-                       path.contains("/Debug/") || path.contains("/Release/");
-            },
+                return path.contains("/build/")
+                    || path.contains("/dist/")
+                    || path.contains("/target/")
+                    || path.contains("/bin/")
+                    || path.contains("/Debug/")
+                    || path.contains("/Release/");
+            }
             // Debug databases
             "idb" | "pdb" => return true,
             // Other build artifacts
@@ -316,28 +363,28 @@ fn is_crap_file(path: &str) -> bool {
             _ => {}
         }
     }
-    
+
     // Special handling for egg-info (it's a directory suffix, not a file extension)
     if filename.ends_with(".egg-info") || path.contains(".egg-info/") {
         return true;
     }
-    
+
     // Check if path contains cache directories
-    path.contains("/__pycache__/") ||
-    path.contains("/.pytest_cache/") ||
-    path.contains("/.mypy_cache/") ||
-    path.contains("/.ruff_cache/") ||
-    path.contains("/.sass-cache/") ||
-    path.contains("/.cache/") ||
-    path.contains("/.parcel-cache/") ||
-    path.contains("/.next/") ||
-    path.contains("/.nuxt/") ||
-    path.contains("/.docusaurus/") ||
-    path.contains("/.serverless/") ||
-    path.contains("/.fusebox/") ||
-    path.contains("/.dynamodb/") ||
-    path.contains("/.tern-port") ||
-    path.contains("/.yarn-integrity")
+    path.contains("/__pycache__/")
+        || path.contains("/.pytest_cache/")
+        || path.contains("/.mypy_cache/")
+        || path.contains("/.ruff_cache/")
+        || path.contains("/.sass-cache/")
+        || path.contains("/.cache/")
+        || path.contains("/.parcel-cache/")
+        || path.contains("/.next/")
+        || path.contains("/.nuxt/")
+        || path.contains("/.docusaurus/")
+        || path.contains("/.serverless/")
+        || path.contains("/.fusebox/")
+        || path.contains("/.dynamodb/")
+        || path.contains("/.tern-port")
+        || path.contains("/.yarn-integrity")
 }
 
 #[tokio::main]
@@ -385,23 +432,23 @@ async fn main() -> Result<(), ()> {
         .arg(".")
         .output()
         .expect("Failed to add files");
-    
+
     // Get list of all files in the repository
     let all_files_output = Command::new("git")
         .arg("ls-files")
         .arg("--cached")
         .output()
         .expect("Failed to list git files");
-    
+
     let all_files = str::from_utf8(&all_files_output.stdout).unwrap();
     let mut unstaged_security = false;
     let mut unstaged_modules = false;
     let mut unstaged_crap = false;
-    
+
     for file_path in all_files.lines() {
         let mut should_unstage = false;
         let mut reason = "";
-        
+
         // Check security files
         if !cli.ok_to_send_env {
             if let Some(filename) = Path::new(file_path).file_name() {
@@ -414,52 +461,58 @@ async fn main() -> Result<(), ()> {
                 }
             }
         }
-        
+
         // Check module directories
         if !cli.yes_to_modules && is_module_directory(file_path) {
             should_unstage = true;
             reason = "dependency/module folder";
             unstaged_modules = true;
         }
-        
+
         // Check crap files
         if !cli.yes_to_crap && is_crap_file(file_path) {
             should_unstage = true;
             reason = "cache/build artifact";
             unstaged_crap = true;
         }
-        
+
         if should_unstage {
-            info!("🛡️  Protecting {} ({}): {}", reason, 
-                if reason == "security file" { "use --ok-to-send-env to include" }
-                else if reason == "dependency/module folder" { "use --yes-to-modules to include" }
-                else { "use --yes-to-crap to include" },
+            info!(
+                "🛡️  Protecting {} ({}): {}",
+                reason,
+                if reason == "security file" {
+                    "use --ok-to-send-env to include"
+                } else if reason == "dependency/module folder" {
+                    "use --yes-to-modules to include"
+                } else {
+                    "use --yes-to-crap to include"
+                },
                 file_path
             );
-            
+
             let unstage_result = Command::new("git")
                 .arg("reset")
                 .arg("HEAD")
                 .arg(file_path)
                 .output();
-            
+
             if let Err(e) = unstage_result {
                 error!("⚠️  Failed to unstage {}: {}", file_path, e);
             }
         }
     }
-    
+
     // Show summary messages
     if unstaged_security {
         info!("🔒 Unstaged security files to protect your secrets!");
         info!("💡 Use --ok-to-send-env if you really want to include them (not recommended)");
     }
-    
+
     if unstaged_modules {
         info!("📦 Unstaged dependency folders to keep your repo size reasonable!");
         info!("💡 Use --yes-to-modules if you really want to include them (repo will be HUGE!)");
     }
-    
+
     if unstaged_crap {
         info!("🗑️  Unstaged cache/build artifacts to keep your repo clean!");
         info!("💡 Use --yes-to-crap if you really want to include them (not recommended)");
@@ -534,7 +587,12 @@ async fn main() -> Result<(), ()> {
     });
     let mut generator = SchemaGenerator::new(settings);
 
-    let commit_schema = generator.subschema_for::<Commit>();
+    let commit_schema = generator.subschema_for::<CommitAdvice>();
+
+    let mut system_prompt = "You are an experienced programmer who writes great commit messages. Analyze the git diff and return JSON with a 'message' for the noob developer and a 'commit' containing title and description. If you find any API keys, mention 'WARNING!!! API_KEY DETECTED IN THIS PART' in the message.".to_string();
+    if cli.br_huehuehue {
+        system_prompt.push_str(" Respond in Brazilian Portuguese with a playful tone and add 'huehuehue' when it makes sense.");
+    }
 
     let completion = client
         .chat()
@@ -542,25 +600,29 @@ async fn main() -> Result<(), ()> {
             CreateChatCompletionRequestArgs::default()
                 .messages(vec![
                     ChatCompletionRequestMessage::System(ChatCompletionRequestSystemMessage {
-                        content: ChatCompletionRequestSystemMessageContent::Text("You are an experienced programmer who writes great commit messages. Analyze the git diff and create a commit with a clear title and description that explains what changed and why.".to_string()),
+                        content: ChatCompletionRequestSystemMessageContent::Text(system_prompt),
                         name: None,
                     }),
                     ChatCompletionRequestMessage::User(ChatCompletionRequestUserMessage {
-                        content: ChatCompletionRequestUserMessageContent::Text(format!("Here's the git diff:\n{}", output)),
+                        content: ChatCompletionRequestUserMessageContent::Text(format!(
+                            "Here's the git diff:\n{}",
+                            output
+                        )),
                         name: None,
                     }),
                 ])
-                .tools(vec![
-                    ChatCompletionTool {
-                        r#type: ChatCompletionToolType::Function,
-                        function: FunctionObject {
-                            name: "commit".to_string(),
-                            description: Some("Creates a commit with the given title and description.".to_string()),
-                            parameters: Some(serde_json::to_value(commit_schema).unwrap()),
-                            strict: Some(false),
-                        },
+                .tools(vec![ChatCompletionTool {
+                    r#type: ChatCompletionToolType::Function,
+                    function: FunctionObject {
+                        name: "commit".to_string(),
+                        description: Some(
+                            "Returns a message for the developer and a structured commit."
+                                .to_string(),
+                        ),
+                        parameters: Some(serde_json::to_value(commit_schema).unwrap()),
+                        strict: Some(false),
                     },
-                ])
+                }])
                 .tool_choice("commit".to_string())
                 .model(&cli.model)
                 .temperature(0.0)
@@ -576,11 +638,11 @@ async fn main() -> Result<(), ()> {
     }
 
     let tool_calls = &completion.choices[0].message.tool_calls;
-    let commit_msg = if let Some(tool_calls) = tool_calls {
+    let (noob_msg, commit_msg) = if let Some(tool_calls) = tool_calls {
         if let Some(tool_call) = tool_calls.first() {
-            serde_json::from_str::<Commit>(&tool_call.function.arguments)
-                .expect("Couldn't parse model response.")
-                .to_string()
+            let advice: CommitAdvice = serde_json::from_str(&tool_call.function.arguments)
+                .expect("Couldn't parse model response.");
+            (advice.message, advice.commit.to_string())
         } else {
             error!("No tool calls in response");
             std::process::exit(1);
@@ -592,12 +654,14 @@ async fn main() -> Result<(), ()> {
 
     if cli.dry_run {
         info!("{}", commit_msg);
+        info!("{}", noob_msg);
         return Ok(());
     } else {
         info!(
             "Proposed Commit:\n------------------------------\n{}\n------------------------------",
             commit_msg
         );
+        info!("Advice: {}", noob_msg);
 
         if !cli.force {
             let answer = Question::new("Do you want to continue? (Y/n)")
@@ -644,7 +708,7 @@ async fn main() -> Result<(), ()> {
             .arg("push")
             .output()
             .expect("Failed to push to remote");
-        
+
         if push_output.status.success() {
             info!("🚀 Pushed to remote! Your code is now bothering other developers.");
         } else {
@@ -653,6 +717,9 @@ async fn main() -> Result<(), ()> {
         }
     }
 
+    if !cli.no_f_ads {
+        info!("One more noob commit by arthrod/noob-commit 🤡");
+    }
+
     Ok(())
 }
-// Test change

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8,13 +8,14 @@ fn test_help_command() {
         .expect("Failed to execute help command");
 
     let stdout = String::from_utf8(output.stdout).unwrap();
-    
+
     // Check that help contains our noob-friendly messages
     assert!(stdout.contains("For devs who code like ninjas but commit like toddlers"));
     assert!(stdout.contains("🤡"));
     assert!(stdout.contains("nc"));
     assert!(stdout.contains("setup-alias"));
     assert!(stdout.contains("YOLO mode"));
+    assert!(stdout.contains("-b, --br-huehuehue"));
 }
 
 #[test]
@@ -38,7 +39,7 @@ fn test_dry_run_without_openai_key() {
         .expect("Failed to execute dry-run command");
 
     let stderr = String::from_utf8(output.stderr).unwrap();
-    
+
     // Should fail with noob-friendly error about API key
     assert!(stderr.contains("forgot to set OPENAI_API_KEY"));
     assert!(stderr.contains("🔑"));
@@ -50,19 +51,19 @@ fn test_non_git_directory() {
     // Create a temporary directory outside of any git repo
     let temp_dir = std::env::temp_dir().join(format!("noob-commit-test-{}", std::process::id()));
     std::fs::create_dir_all(&temp_dir).unwrap();
-    
+
     // Make sure there's no .git directory
     if temp_dir.join(".git").exists() {
         std::fs::remove_dir_all(temp_dir.join(".git")).ok();
     }
-    
+
     // Use the binary directly instead of cargo run
     let binary_path = std::env::current_dir()
         .unwrap()
         .join("target")
         .join("debug")
         .join("noob-commit");
-    
+
     let output = Command::new(&binary_path)
         .args(&["--dry-run"])
         .current_dir(&temp_dir)
@@ -71,16 +72,20 @@ fn test_non_git_directory() {
         .expect("Failed to execute command");
 
     let stderr = String::from_utf8(output.stderr).unwrap();
-    
+
     // Should fail with noob-friendly error about not being in git repo OR no staged files
     // (depending on the git setup, it might detect as non-repo or no files)
-    let valid_errors = stderr.contains("isn't a git repo") || 
-                      stderr.contains("Nothing to commit") ||
-                      stderr.contains("🙈") || 
-                      stderr.contains("🤷");
-    
-    assert!(valid_errors, "Expected git repo error or no files error, got: {}", stderr);
-    
+    let valid_errors = stderr.contains("isn't a git repo")
+        || stderr.contains("Nothing to commit")
+        || stderr.contains("🙈")
+        || stderr.contains("🤷");
+
+    assert!(
+        valid_errors,
+        "Expected git repo error or no files error, got: {}",
+        stderr
+    );
+
     // Cleanup
     std::fs::remove_dir_all(&temp_dir).ok();
 }
@@ -102,21 +107,23 @@ mod cli_tests {
     fn test_all_flags_present() {
         let output = run_noob_commit(&["--help"]);
         let stdout = String::from_utf8(output.stdout).unwrap();
-        
+
         // Test all our custom flags are present
         let expected_flags = [
-            "--dry-run",
-            "--review", 
-            "--force",
-            "--ok-to-send-env",
-            "--no-push",
-            "--max-tokens",
-            "--model",
-            "--setup-alias",
-            "--yes-to-modules",
-            "--yes-to-crap"
+            "-d, --dry-run",
+            "-r, --review",
+            "-f, --force",
+            "-e, --ok-to-send-env",
+            "-p, --no-push",
+            "-t, --max-tokens",
+            "-m, --model",
+            "-s, --setup-alias",
+            "-M, --yes-to-modules",
+            "-c, --yes-to-crap",
+            "-b, --br-huehuehue",
+            "-a, --no-f-ads",
         ];
-        
+
         for flag in &expected_flags {
             assert!(stdout.contains(flag), "Missing flag: {}", flag);
         }
@@ -126,10 +133,10 @@ mod cli_tests {
     fn test_emoji_usage() {
         let output = run_noob_commit(&["--help"]);
         let stdout = String::from_utf8(output.stdout).unwrap();
-        
+
         // Test that we use emojis for fun
         let expected_emojis = ["🤡", "🔍", "✏️", "⚡", "🔓", "📦", "🤖", "🧠", "🛠️", "🗑️"];
-        
+
         for emoji in &expected_emojis {
             assert!(stdout.contains(emoji), "Missing emoji: {}", emoji);
         }
@@ -139,7 +146,7 @@ mod cli_tests {
     fn test_default_values() {
         let output = run_noob_commit(&["--help"]);
         let stdout = String::from_utf8(output.stdout).unwrap();
-        
+
         // Test default values are set correctly
         assert!(stdout.contains("gpt-4.1-mini"));
         assert!(stdout.contains("2000"));


### PR DESCRIPTION
### **User description**
## Summary
- add `--no-f-ads` / `-a` option to toggle short post-commit tagline
- print a funny line after committing unless the flag is used
- instruct OpenAI to warn about API keys and update CLI help tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684092516fcc832b8f0b7c2664a2bbba


___

### **PR Type**
Enhancement, Documentation, Tests


___

### **Description**
- Add `--no-f-ads` and `--br-huehuehue` CLI flags for customization
  - `--no-f-ads`: disables post-commit tagline
  - `--br-huehuehue`: outputs advice in Brazilian Portuguese with humor

- Enhance AI commit advice: now returns both a message and structured commit
  - New `CommitAdvice` struct for message + commit
  - System prompt updated to warn about API keys and support humor/Portuguese

- Update documentation and tests for new flags and behaviors
  - README and integration tests reflect new CLI options and outputs

- Refactor and improve code formatting and test coverage


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Add CLI flags and enhance AI commit advice output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main.rs

<li>Added <code>--no-f-ads</code> and <code>--br-huehuehue</code> CLI flags<br> <li> AI now returns both advice message and commit struct (<code>CommitAdvice</code>)<br> <li> System prompt updated for API key warnings and humor/Portuguese<br> <li> Post-commit tagline is now optional<br> <li> Refactored and improved code formatting


</details>


  </td>
  <td><a href="https://github.com/arthrod/noob-commit/pull/18/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fc">+185/-118</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Add CommitAdvice struct and related tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib.rs

<li>Introduced <code>CommitAdvice</code> struct for message + commit<br> <li> Implemented <code>ToString</code> and constructor for <code>CommitAdvice</code><br> <li> Added tests for <code>CommitAdvice</code> functionality<br> <li> Improved formatting and test coverage


</details>


  </td>
  <td><a href="https://github.com/arthrod/noob-commit/pull/18/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759">+41/-20</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document new CLI flags and usage examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Documented new CLI flags: <code>--no-f-ads</code>, <code>--br-huehuehue</code><br> <li> Updated usage examples and flags table<br> <li> Added Portuguese advice example


</details>


  </td>
  <td><a href="https://github.com/arthrod/noob-commit/pull/18/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+18/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>integration_tests.rs</strong><dd><code>Update integration tests for new CLI flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration_tests.rs

<li>Updated tests to check for new CLI flags and outputs<br> <li> Added assertions for <code>--br-huehuehue</code> and <code>--no-f-ads</code><br> <li> Improved formatting and coverage in CLI help tests


</details>


  </td>
  <td><a href="https://github.com/arthrod/noob-commit/pull/18/files#diff-e6b41d2b5ecc7c9a47a8db354ec3916bf8ef2c1cfb29aceb796af5a51a3f22a0">+36/-29</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>